### PR TITLE
feat: add account creation to web UI

### DIFF
--- a/services/web-ui/src/app.js
+++ b/services/web-ui/src/app.js
@@ -11,6 +11,34 @@ const axiosInstance = axios.create({ timeout: 5000 });
 
 let currentAccountId = null;
 
+async function createAccount() {
+  const nameEl = document.getElementById('newUserName');
+  const balanceEl = document.getElementById('newUserBalance');
+  const infoEl = document.getElementById('newAccountInfo');
+  if (!nameEl || !balanceEl || !infoEl) return;
+  const name = nameEl.value.trim();
+  const initialBalance = parseFloat(balanceEl.value);
+  if (!name || isNaN(initialBalance)) {
+    return alert('Bitte Name und Startguthaben eingeben');
+  }
+  infoEl.innerText = 'Erstelle Account...';
+  try {
+    const user = await axiosInstance.post(`${API}/users`, { name });
+    const account = await axiosInstance.post(`${API}/accounts`, {
+      userId: user.data.id,
+      initialBalance
+    });
+    infoEl.innerText = `Account erstellt. ID: ${account.data.id}`;
+    const loginInput = document.getElementById('loginAccountId');
+    if (loginInput) loginInput.value = account.data.id;
+    await login();
+  } catch (e) {
+    console.error('createAccount error:', e);
+    const msg = e.response?.data?.error || 'Fehler beim Erstellen';
+    infoEl.innerText = msg;
+  }
+}
+
 async function login() {
   const idEl = document.getElementById('loginAccountId');
   if (!idEl) return;

--- a/services/web-ui/src/index.html
+++ b/services/web-ui/src/index.html
@@ -8,6 +8,14 @@
 <body>
   <h1>PayTim</h1>
 
+  <div id="register">
+    <h2>Account erstellen</h2>
+    <input id="newUserName" placeholder="Name" />
+    <input id="newUserBalance" type="number" placeholder="Startguthaben" />
+    <button onclick="createAccount()">Erstellen</button>
+    <div id="newAccountInfo"></div>
+  </div>
+
   <div id="login">
     <h2>Account wählen</h2>
     <input id="loginAccountId" placeholder="Account ID" />


### PR DESCRIPTION
## Summary
- allow users to create an account with initial balance via the web UI
- call existing /users and /accounts APIs to provision the new account and log in automatically

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68adcf6c98d8832199aa16acded4d1ff