### PR TITLE
Add dark mode styling to web UI

### DIFF
--- a/services/web-ui/dist/index.html
+++ b/services/web-ui/dist/index.html
@@ -1,12 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="UTF-8">
-<title>PayTim WebUI</title>
+    <meta charset="UTF-8">
+    <title>PayTim WebUI</title>
+    <link rel="stylesheet" href="./style.css">
   <script type="module" crossorigin src="/assets/index-OyLUANkm.js"></script>
 </head>
 <body>
-<div id="root"></div>
+<div id="root"></div>
 TEST
 </body>
+</html>
 </html>

--- a/services/web-ui/dist/style.css
+++ b/services/web-ui/dist/style.css
@@ -1,0 +1,44 @@
+body {
+    margin: 0;
+    padding: 0;
+    background-color: #121212;
+    color: #e0e0e0;
+    font-family: Arial, sans-serif;
+    font-size: 1.2rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    text-align: center;
+}
+
+button {
+    background-color: #1e88e5;
+    color: #fff;
+    border: none;
+    padding: 12px 24px;
+    margin: 8px;
+    border-radius: 4px;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background-color 0.3s;
+}
+
+button:hover {
+    background-color: #1565c0;
+}
+
+a {
+    color: #64b5f6;
+}
+
+input, select, textarea {
+    background-color: #1e1e1e;
+    color: #fff;
+    border: 1px solid #333;
+    padding: 10px;
+    border-radius: 4px;
+    font-size: 1rem;
+    margin: 8px 0;
+}

--- a/services/web-ui/index.html
+++ b/services/web-ui/index.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="UTF-8">
-<title>PayTim WebUI</title>
+    <meta charset="UTF-8">
+    <title>PayTim WebUI</title>
+    <link rel="stylesheet" href="./style.css">
 </head>
 <body>
 <div id="root"></div>

--- a/services/web-ui/style.css
+++ b/services/web-ui/style.css
@@ -1,0 +1,44 @@
+body {
+    margin: 0;
+    padding: 0;
+    background-color: #121212;
+    color: #e0e0e0;
+    font-family: Arial, sans-serif;
+    font-size: 1.2rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    text-align: center;
+}
+
+button {
+    background-color: #1e88e5;
+    color: #fff;
+    border: none;
+    padding: 12px 24px;
+    margin: 8px;
+    border-radius: 4px;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background-color 0.3s;
+}
+
+button:hover {
+    background-color: #1565c0;
+}
+
+a {
+    color: #64b5f6;
+}
+
+input, select, textarea {
+    background-color: #1e1e1e;
+    color: #fff;
+    border: 1px solid #333;
+    padding: 10px;
+    border-radius: 4px;
+    font-size: 1rem;
+    margin: 8px 0;
+}


### PR DESCRIPTION
## Summary
- add shared dark-themed stylesheet with centered layout and blue buttons
- link stylesheet from both web UI HTML entry points

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68ade514cffc8321b1ab6488b40eb573