### PR TITLE
Add auth_users table to ledger migration

### DIFF
--- a/services/ledger-svc/src/db.mjs
+++ b/services/ledger-svc/src/db.mjs
@@ -40,6 +40,12 @@ delta numeric(18,2) not null,
 balance_after numeric(18,2) not null,
 created_at timestamptz not null default now()
 );
+create table if not exists auth_users (
+id uuid primary key,
+user_id uuid references users(id),
+username text unique not null,
+password_hash text not null
+);
 `);
 }
 


### PR DESCRIPTION
## Summary
- extend ledger service migration to create `auth_users` table for authentication data

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68ae31978eb4832183d9e9c692bf028c